### PR TITLE
GHA: add initial workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: perl
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+  create:
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    if: ${{ always() }}
+    steps:
+      - uses: PDLPorters/devops/github-actions/irc-notifications@master
+        with:
+          target-notifications: true
+  ci:
+    runs-on: ${{ matrix.os }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
+    needs: notify
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        perl-version: ['5.10', '5.14', '5.20']
+        include:
+          - perl-version: '5.30'
+            os: ubuntu-latest
+            release-test: true
+            coverage: true
+          #- perl-version: '5.30'
+          #  os: windows-latest
+          - perl-version: '5.30'
+            os: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'ci-dist: target-setup-perl'
+        uses: PDLPorters/devops/github-actions/ci-dist@master
+        with:
+          target-setup-perl: true
+          perl-version: ${{ matrix.perl-version }}
+      - name: Install PLplot
+        uses: PDLPorters/devops/github-actions/install-dep-plplot@master
+      - name: Install PDL dependencies
+        if: matrix.os == 'ubuntu-latest'
+        uses: PDLPorters/devops/github-actions/install-dep-pdl-dep@master
+      - name: Install Perl configure deps
+        run: |
+          cpanm PDL::Core::Dev
+      - name: 'ci-dist: target-all'
+        uses: PDLPorters/devops/github-actions/ci-dist@master
+        with:
+          target-setup-perl: false
+          target-install-dist-perl-deps: true
+          target-test-release-testing: true
+          target-test: true
+          test-enable-release-testing: ${{ matrix.release-test }}
+          test-enable-coverage: ${{ matrix.coverage }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-status:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    if: ${{ always() }}
+    needs: [ 'ci' ]
+    steps:
+      - uses: PDLPorters/devops/github-actions/irc-notifications@master
+        with:
+          target-build-status: true
+          needs: ${{ toJSON(needs) }}

--- a/.github/workflows/issue-notify.yml
+++ b/.github/workflows/issue-notify.yml
@@ -1,0 +1,17 @@
+name: issue-notify
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    if: ${{ always() }}
+    steps:
+      - uses: PDLPorters/devops/github-actions/irc-notifications@master
+        with:
+          target-notifications: true

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -74,3 +74,5 @@ PLplot.xs
 temp
 
 ^xt/
+
+^.github/


### PR DESCRIPTION
Connects with <https://github.com/PDLPorters/devops/pull/8>.

Of note, the Coveralls support is not yet enabled because Coveralls is
currently down <https://status.coveralls.io/incidents/ppvnbpd172gy>.
