### PR TITLE
Relax PLplot version to ≥ v5.13 + enable GHA on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
             os: ubuntu-latest
             release-test: true
             coverage: true
-          #- perl-version: '5.30'
-          #  os: windows-latest
+          - perl-version: '5.30'
+            os: windows-latest
           - perl-version: '5.30'
             os: macos-latest
     steps:

--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 - doc improvement for dates in XBOX - thanks @mvgrimes
+- relax required PLplot version to 5.13.0+.
 
 0.77 2021-07-30
 - fix logic error in plslabelfunc

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,7 +8,7 @@ use Data::Dumper;
 use PDL::Core::Dev;
 
 my $PL_MAJOR = 5; # minimum required
-my $PL_MINOR = 15;
+my $PL_MINOR = 13;
 
 unlink ("OPTIONS!"); # remove file used to communicate with plplot.pd
 

--- a/plplot.pd
+++ b/plplot.pd
@@ -27,8 +27,9 @@ PDL::Graphics::PLplot - Object-oriented interface from perl/PDL to the PLPLOT pl
   $pl->xyplot($x, $y);
   $pl->close;
 
-Only version 5.15.0+ of PLplot is supported, due to a C-level API change
-that is invisible at PDL-level.
+Only version 5.15.0+ of PLplot is fully supported, due to a C-level API change
+that is invisible at PDL-level. However, the library does support installation
+with PLplot 5.13.0+.
 
 For more information on PLplot, see
 

--- a/t/plplot_library_tests.t
+++ b/t/plplot_library_tests.t
@@ -27,8 +27,18 @@ my $plversion = do "$maindir/OPTIONS!";
 
 my $tmpdir = tempdir( CLEANUP => 1 );
 
+# Test numbers to skip on incompatible versions of PLplot
+my %skip_num = (
+  '01' => qr/^5\.13\./,
+  '15' => qr/^5\.13\./,
+);
+
+my $plgver = plgver();
 foreach my $plplot_test_script (@scripts) {
   my ($num) = ($plplot_test_script =~ /x(\d\d)\.pl/);
+SKIP: {
+  skip "Skipping test script $num on PLplot $plgver", 1 if exists $skip_num{$num} && $plgver =~ $skip_num{$num};
+subtest "Test script: $num" => sub {
   (my $c_code = $plplot_test_script) =~ s/\.pl/c\.c/;
 
   # Compile C version
@@ -57,6 +67,8 @@ foreach my $plplot_test_script (@scripts) {
     (my $reffile = $perlfile) =~ s/x(\d\d)p/x${1}c/;
     cmp_files($perlfile, $reffile);
   }
+};
+}
 }
 
 done_testing;


### PR DESCRIPTION
As discussed in IRC, some of the tests can be skipped on older versions of
PLplot due to incompatibilities, but this does not interfere with the output of
the rest of the library tests.
