### PR TITLE
Remove non-include paths from INC in pre-build checks

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -117,10 +117,10 @@ sub compileAndRun {
   my $inc = join " ", grep /^-I/, shellwords($plplot_include_path);
 
   check_lib(
-    ccflags  => "$plplot_include_path",
-    ldflags  => "$libs",
-    INC      => "$inc",
-    LIBS     => "$libs",
+    ccflags  => $plplot_include_path,
+    ldflags  => $libs,
+    INC      => $inc,
+    LIBS     => $libs,
     header   => [ 'stdio.h', $header ],
     function => $code,
     analyze_binary => sub {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,6 +4,7 @@ use ExtUtils::MakeMaker;
 use Config;
 use File::Spec;
 use Data::Dumper;
+use Text::ParseWords qw(shellwords);
 
 use PDL::Core::Dev;
 use Devel::CheckLib;
@@ -113,10 +114,12 @@ sub compileAndRun {
   my ($code) = @_;
   my $result;
 
+  my $inc = join " ", grep /^-I/, shellwords($plplot_include_path);
+
   check_lib(
     ccflags  => "$plplot_include_path",
     ldflags  => "$libs",
-    INC      => "$plplot_include_path",
+    INC      => "$inc",
     LIBS     => "$libs",
     header   => [ 'stdio.h', $header ],
     function => $code,


### PR DESCRIPTION
While trying to get `PDL::Graphics::PLplot` to install, I found it kept telling me that it needed a plplot library compiled with the `--with-double` option:

```
$ perl Makefile.PL
Use of uninitialized value $size in numeric eq (==) at Makefile.PL line 46.
Sizeof(PLFLT) must be 8.
PLplot must be compiled --with-double (IE ./configure --with-double).

Please either:
- Install PLplot using your package manager then reinstall Alien::PLplot
  or
- Reinstall Alien::PLplot from CPAN with environment variable
  ALIEN_INSTALL_TYPE=share.
```

After having tried the advice about reinstalling `Alien::PLplot` and failing, and having checked that `libplplot` had been installed using double precision, I happened to stumble upon the issue that the option `-pthread` was appearing in the `$plplot_include_path` variable.  I noticed this by replacing the call to `check_lib` (from `Devel::CheckLib`) with `check_lib_or_exit`.  When using this function, the error output was this instead:

```
$ perl Makefile.PL
INC argument badly-formed: -pthread
```

Upon reading the docs for `Devel::CheckLib`, it turns out that the `INC` option to both `check_lib` and `check_lib_or_exit` needs to be a space-delimited list of options, all of which start with `-I`.  Since `-pthread` doesn't start with `-I` the argument was badly formed, hence the `analyze_binary` callback was never called.  Thus no check code was compiled which then resulted in `$size` being set to `undef`.  Because `$size` was `undef`, the uninitialized value warning mentioned in the first error message mentione above and the check for a double precision library failed.  In other words, because `-pthread` was turning up in the `$plplot_include_path` string, the test for a library compiled with the `--with-double` option was failing and hence `PDL::Graphics::PLplot` failed to install.

By filtering only for include paths from the list of options originally found in `$plplot_include_path` (i.e. selecting only options starting with `-I` and hence excluding in this particular instance the `-pthread` option), one avoids the issue of a badly formed INC argument and thus the checks in `Makefile.PL` compile and run.  Because all checks run, the `Makefile` is created as per normal and the test suite passes.

More background info: I found this issue on Debian version 11.11 with a perlbrewed perl, version 5.32.1.

This PR is submitted in the hope that it is useful. If you'd like anything changed, please let me know and I'll update and resubmit as necessary.